### PR TITLE
chore(docker): add official Next.js Dockerfile (pnpm, standalone)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Based on Next.js with-docker example .dockerignore
+
+# Dependencies
+node_modules
+
+# Build output
+.next
+out
+dist
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Git
+.git
+.gitignore
+
+# Editors
+.vscode
+.idea
+
+# Misc
+Dockerfile
+Dockerfile.*
+*.md
+*.map
+.DS_Store
+*.tsbuildinfo
+
+# Env (do not bake secrets into images)
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# Axelot note: This file is copied exactly from Next.js' official with-docker example.
+# It relies on Next.js standalone output (we enable it in next.config.ts).
+
+# syntax=docker.io/docker/dockerfile:1
+
+FROM node:20-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+RUN \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN \
+  if [ -f yarn.lock ]; then yarn run build; \
+  elif [ -f package-lock.json ]; then npm run build; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 12. [Contribution Guidelines](#contribution-guidelines)
 13. [License](#license)
 14. [Mermaid Diagrams](#mermaid-diagrams)
+15. [Docker](#docker)
 
 ---
 
@@ -254,3 +255,19 @@ Distributed under the AGPL-3.0 License. See `LICENSE` for more information.
 ---
 
 <sub>© 2025 Royce Mathew & Sunny Patel. Built with ❤️ for developers. Contributions welcome.</sub>
+
+## Docker
+
+This project includes a production-ready Dockerfile based on Next.js' official "with-docker" example, adapted for pnpm and standalone output.
+
+Build and run locally:
+
+```powershell
+docker build -t axelot:dev .
+docker run --rm -p 3000:3000 --env-file .env.local axelot:dev
+```
+
+Notes:
+- We set `output: "standalone"` in `next.config.ts` to enable the minimal runtime bundle.
+- Do not bake secrets into images; supply env via `--env-file` or your platform's secret manager.
+- Container binds to `0.0.0.0:3000`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next"
 
+// Added for Docker (standalone runtime):
+// Setting output to "standalone" allows the Dockerfile to copy the
+// minimal server files from .next/standalone for a slimmer image.
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 }
 
 export default nextConfig


### PR DESCRIPTION
Adds Dockerfile copied from Next.js with-docker example, adapted for pnpm. Build stage installs deps using the detected lockfile, then runs pnpm build. Runner stage uses Next.js standalone output, copying .next/standalone and .next/static, and starts the app with node server.js on port 3000.

Notes:
- Requires output: 'standalone' in `next.config.ts` (safe for Vercel/Firebase).
- Runtime env vars are provided via `--env-file .env.local` (no secrets baked).

Run locally:
  `docker build -t axelot:dev . docker run --rm -p 3000:3000 --env-file .env.local axelot:dev`

Summary
- What does this PR change and why?

Type of change
- refactor and chore

Scope / Areas
- Build / Deploy (Local Dockerization)